### PR TITLE
replace iirnotch repeated application with butterworth filter

### DIFF
--- a/xcp_d/utils/confounds.py
+++ b/xcp_d/utils/confounds.py
@@ -405,19 +405,22 @@ def motion_regression_filter(
         bandwidth = np.abs(np.diff(stopband_hz))
 
         # Create filter coefficients.
-        b, a = iirnotch(freq_to_remove, freq_to_remove / bandwidth, fs=sampling_frequency)
-        n_filter_applications = int(np.floor(motion_filter_order / 2))
+        b, a = butter(
+            motion_filter_order / 2,
+            stopband_hz,
+            btype="bandstop",
+            output="ba",
+            fs=sampling_frequency,
+        )
 
         filtered_data = data.copy()
-        for _ in range(n_filter_applications):
-            filtered_data = filtfilt(
-                b,
-                a,
-                filtered_data,
-                axis=0,
-                padtype="constant",
-                padlen=data.shape[0] - 1,
-            )
+        filtered_data = filtfilt(
+            b,
+            a,
+            data,
+            axis=0,
+            padtype="constant",
+            padlen=data.shape[0] - 1,
 
     return filtered_data
 


### PR DESCRIPTION
1) The iirnotch() from scipy was second-order, and filtfilt() doubles it. So if repeated application is used here, n_filter_applications should be int(np.floor(motion_filter_order/4)) not int(np.floor(motion_filter_order/2)). 

2) notch filter removes the center frequency much more than the other frequencies in the band but butterworth filter is more flat and removes the whole band more evenly

3) Also applying the filter multiple times instead of changing the order in the filter design seems to be reducing the signal amplitude.
For low-order like 4, it barely matters but if the order is increased to 10, the effect of repeated filtering versus changing the order in the butter() function seems to be more profound. I don't know why it would behave like that but this is just an observation.
![image](https://github.com/user-attachments/assets/456a400d-7bc4-4927-9dc3-271c67fd064c)

<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
-->

## Changes proposed in this pull request
<!--
Please describe here the main features / changes proposed for review and integration in xcp_d
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *xcp_d* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
